### PR TITLE
che #14963 Initial implementation of the codeready specific chectl

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug": "^4.1.1",
     "eclipse-che": "git://github.com/eclipse/che#7.3.1",
     "eclipse-che-minishift": "git://github.com/minishift/minishift#master",
-    "eclipse-che-operator": "git://github.com/eclipse/che-operator#7.3.1",
+    "eclipse-che-operator": "git://github.com/redhat-developer/codeready-workspaces-operator#master",
     "esprima": "^4.0.1",
     "execa": "^2.0.0",
     "fancy-test": "^1.4.4",

--- a/src/api/che.ts
+++ b/src/api/che.ts
@@ -108,7 +108,7 @@ export class CheHelper {
   }
 
   async cheOpenShiftURL(namespace = ''): Promise<string> {
-    const route_names = ['che', 'che-host']
+    const route_names = ['codeready', 'che-host']
     for (const route_name of route_names) {
       if (await this.oc.routeExist(route_name, namespace)) {
         const protocol = await this.oc.getRouteProtocol(route_name, namespace)

--- a/src/api/kube.ts
+++ b/src/api/kube.ts
@@ -946,7 +946,7 @@ export class KubeHelper {
         yamlCr.spec.k8s.tlsSecretName = 'che-tls'
       }
       yamlCr.spec.server.selfSignedCert = flags['self-signed-cert']
-      yamlCr.spec.k8s.ingressDomain = flags.domain
+      // yamlCr.spec.k8s.ingressDomain = flags.domain
       let pluginRegistryUrl = flags['plugin-registry-url']
       if (pluginRegistryUrl) {
         yamlCr.spec.server.pluginRegistryUrl = pluginRegistryUrl

--- a/src/tasks/che.ts
+++ b/src/tasks/che.ts
@@ -28,20 +28,20 @@ export class CheTasks {
   cheNamespace: string
 
   cheAccessToken: string
-  cheSelector = 'app=che,component=che'
+  cheSelector = 'app=codeready,component=codeready'
   cheDeploymentName: string
 
   keycloakDeploymentName = 'keycloak'
-  keycloakSelector = 'app=che,component=keycloak'
+  keycloakSelector = 'app=codeready,component=keycloak'
 
   postgresDeploymentName = 'postgres'
-  postgresSelector = 'app=che,component=postgres'
+  postgresSelector = 'app=codeready,component=postgres'
 
   devfileRegistryDeploymentName = 'devfile-registry'
-  devfileRegistrySelector = 'app=che,component=devfile-registry'
+  devfileRegistrySelector = 'app=codeready,component=devfile-registry'
 
   pluginRegistryDeploymentName = 'plugin-registry'
-  pluginRegistrySelector = 'app=che,component=plugin-registry'
+  pluginRegistrySelector = 'app=codeready,component=plugin-registry'
 
   constructor(flags: any) {
     this.kube = new KubeHelper(flags)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,9 +1673,9 @@ ecc-jsbn@~0.1.1:
   version "0.0.0"
   resolved "git://github.com/minishift/minishift#0efa5d527d77a7651eac75a4861097ab4a203f43"
 
-"eclipse-che-operator@git://github.com/eclipse/che-operator#7.3.1":
+"eclipse-che-operator@git://github.com/redhat-developer/codeready-workspaces-operator#master":
   version "0.0.0"
-  resolved "git://github.com/eclipse/che-operator#d4d7df7df4a4627aa212158be18ff94f867e8dc7"
+  resolved "git://github.com/redhat-developer/codeready-workspaces-operator#f765f8a17c2cdca9539534d4fdaa2e59c063d72e"
 
 "eclipse-che@git://github.com/eclipse/che#7.3.1":
   version "0.0.0"


### PR DESCRIPTION
### What does this PR do?
Initial implementation of the `codeready` specific chectl:

- changing selectors to be `codeready` specific
- referring to the codeready-workspaces-operator https://github.com/ibuziuk/codeready-workspaces-operator instead of upstream one
- commenting out `ingressDomain` (will be removed as part of k8s support cleanup)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14963

### Notes 

Tested via `./run server:start -a operator -p crc -b console-openshift-console.apps-crc.testing -n che --che-operator-cr-yaml=cr.yaml`

Where `cr.yaml` - https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/master/operator-installer/custom-resource.yaml

![image](https://user-images.githubusercontent.com/1461122/67976962-6aeee800-fc17-11e9-9d1e-39e025ea33a8.png)


Without specifying the `--che-operator-cr-yaml` deployment fails on:

> Failed to pull image "registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.0": rpc error: code = Unknown desc = Error reading manifest 2.0 in registry.redhat.io/codeready-workspaces/devfileregistry-rhel8: unknown: Not Found

I suppose this is expected for now