### PR TITLE
Wait for the right deployment name

### DIFF
--- a/src/common-flags.ts
+++ b/src/common-flags.ts
@@ -11,14 +11,14 @@ import { string } from '@oclif/parser/lib/flags'
 
 export const cheNamespace = string({
   char: 'n',
-  description: 'Kubernetes namespace where Che server is supposed by be deployed',
+  description: 'Kubernetes namespace where CodeReady Workspaces server is supposed by be deployed',
   default: 'che',
   env: 'CHE_NAMESPACE'
 })
 
 export const cheDeployment = string({
   description: 'Che deployment name',
-  default: 'che',
+  default: 'codeready',
   env: 'CHE_DEPLOYMENT'
 })
 

--- a/src/tasks/installers/operator.ts
+++ b/src/tasks/installers/operator.ts
@@ -21,14 +21,14 @@ import { CheHelper } from '../../api/che'
 import { KubeHelper } from '../../api/kube'
 
 export class OperatorTasks {
-  operatorServiceAccount = 'che-operator'
-  operatorRole = 'che-operator'
-  operatorClusterRole = 'che-operator'
-  operatorRoleBinding = 'che-operator'
-  operatorClusterRoleBinding = 'che-operator'
+  operatorServiceAccount = 'codeready-operator'
+  operatorRole = 'codeready-operator'
+  operatorClusterRole = 'codeready-operator'
+  operatorRoleBinding = 'codeready-operator'
+  operatorClusterRoleBinding = 'codeready-operator'
   cheClusterCrd = 'checlusters.org.eclipse.che'
-  operatorName = 'che-operator'
-  operatorCheCluster = 'eclipse-che'
+  operatorName = 'codeready-operator'
+  operatorCheCluster = 'codeready-workspaces'
   resourcesPath = ''
 
   /**


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

In the case of CRW, we should wait for the `codeready` deployment, instead of the `che` deployment by default.
It also chnage the expected name of other installation components such as the operator deployment name, service account, role bindings, etc ...

### What  issues does this PR fix or reference?

It should fix the issue https://issues.jboss.org/browse/CRW-462