### PR TITLE
By default install crw in `workspaces` namespace

### DIFF
--- a/src/common-flags.ts
+++ b/src/common-flags.ts
@@ -12,7 +12,7 @@ import { string } from '@oclif/parser/lib/flags'
 export const cheNamespace = string({
   char: 'n',
   description: 'Kubernetes namespace where CodeReady Workspaces server is supposed to be deployed',
-  default: 'che',
+  default: 'workspaces',
   env: 'CHE_NAMESPACE'
 })
 


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

This PR fixes issue https://issues.jboss.org/browse/CRW-471

It should install CRW by default in the `workspaces` namespace, and not the `che` namespace

### What issues does this PR fix or reference?

