### PR TITLE
build crwctl win32-x64 binary

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,49 +16,46 @@ def CTL_path = "codeready-workspaces-chectl"
 def SHA_CTL = "SHA_CTL"
 
 timeout(180) {
-	node("rhel7-releng"){ withCredentials([string(credentialsId: 'codeready-bot', variable: 'GITHUB_TOKEN')]) { stage "Build ${CTL_path}"
-		cleanWs()
-		checkout([$class: 'GitSCM', 
-			branches: [[name: "${branchToBuildCTL}"]], 
-			doGenerateSubmoduleConfigurations: false, 
-			poll: true,
-			extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "${CTL_path}"]], 
-			submoduleCfg: [], 
-			userRemoteConfigs: [[url: "https://github.com/redhat-developer/${CTL_path}.git"]]])
-		installNPM()
-		def CURRENT_DAY=sh(returnStdout:true,script:"date +'%Y%m%d'").trim()
-        def SHORT_SHA1=sh(returnStdout:true,script:"cd ${CTL_path}/ && git rev-parse --short HEAD").trim()
-        def CHECTL_VERSION="0.0.$CURRENT_DAY-next"
-        def GITHUB_RELEASE_NAME="0.0.$CURRENT_DAY-next.${SHORT_SHA1}"
-		def CUSTOM_TAG=sh(returnStdout:true,script:"date +'%Y%m%d%H%M%S'").trim()
-		SHA_CTL = sh(returnStdout:true,script:"cd ${CTL_path}/ && git rev-parse --short=4 HEAD").trim()
-		sh "cd ${CTL_path}/ && sed -i -e 's#version\": \"\\(.*\\)\",#version\": \"'${CHECTL_VERSION}'\",#' package.json"
-		sh "cd ${CTL_path}/ && egrep -v 'versioned|oclif' package.json | grep -e version"
-        sh "cd ${CTL_path}/ && git tag '${CUSTOM_TAG}'"
-		sh "rm ${CTL_path}/yarn.lock"
-		// remove windows 7z if installed
-		sh "rm -fr ${nodePath}/lib/node_modules/7zip"
-		// link to rpm-installed p7zip
-		sh "if [[ -x /usr/bin/7za ]]; then pushd ${nodePath}/bin >/dev/null; rm -f 7z*; ln -s /usr/bin/7za 7z; popd >/dev/null; fi"
-		sh "cd ${CTL_path}/ && yarn && npx oclif-dev pack -t ${platforms} && find ./dist/ -name \"*.tar*\""
-        def RELEASE_DESCRIPTION="CI release ${GITHUB_RELEASE_NAME}"
-		sh "curl -XPOST -H 'Authorization:token ${GITHUB_TOKEN}' --data '{\"tag_name\": \"${CUSTOM_TAG}\", \"target_commitish\": \"master\", \"name\": \"${GITHUB_RELEASE_NAME}\", \"body\": \"${RELEASE_DESCRIPTION}\", \"draft\": false, \"prerelease\": true}' https://api.github.com/repos/redhat-developer/codeready-workspaces-chectl/releases > /tmp/${CUSTOM_TAG}"
-		// Extract the id of the release from the creation response
-        def RELEASE_ID=sh(returnStdout:true,script:"jq -r .id /tmp/${CUSTOM_TAG}").trim()
-		// Upload the artifacts
-        sh "cd ${CTL_path}/dist/channels/next/ && curl -XPOST -H 'Authorization:token ${GITHUB_TOKEN}' -H 'Content-Type:application/octet-stream' --data-binary @crwctl-linux-x64.tar.gz https://uploads.github.com/repos/redhat-developer/codeready-workspaces-chectl/releases/${RELEASE_ID}/assets?name=crwctl-linux-x64.tar.gz"
-        sh "cd ${CTL_path}/dist/channels/next/ && curl -XPOST -H 'Authorization:token ${GITHUB_TOKEN}' -H 'Content-Type:application/octet-stream' --data-binary @crwctl-win32-x64.tar.gz https://uploads.github.com/repos/redhat-developer/codeready-workspaces-chectl/releases/${RELEASE_ID}/assets?name=crwctl-win32-x64.tar.gz"
-        sh "cd ${CTL_path}/dist/channels/next/ && curl -XPOST -H 'Authorization:token ${GITHUB_TOKEN}' -H 'Content-Type:application/octet-stream' --data-binary @crwctl-darwin-x64.tar.gz https://uploads.github.com/repos/redhat-developer/codeready-workspaces-chectl/releases/${RELEASE_ID}/assets?name=crwctl-darwin-x64.tar.gz"
-        // refresh github pages
-		sh "cd ${CTL_path}/ && git clone https://devstudio-release:${GITHUB_TOKEN}@github.com/redhat-developer/codeready-workspaces-chectl -b gh-pages --single-branch gh-pages"
-		sh "cd ${CTL_path}/ && echo \$(date +%s) > gh-pages/update"
-		sh "cd ${CTL_path}/gh-pages && git add update && git commit -m \"Update github pages\" && git push origin gh-pages"
-		stash name: 'stashDist', includes: findFiles(glob: "${CTL_path}/dist/").join(", ")
-	}}
-}
-timeout(180) {
-	node("rhel7-releng"){ stage "Publish ${CTL_path}"
-		unstash 'stashDist'
-		archiveArtifacts fingerprint: false, artifacts:"**/*.log, **/*logs/**, **/dist/**/*.tar.gz, **/dist/*.json, **/dist/linux-x64, **/dist/win32-x64, **/dist/darwin-x64"
+	node("rhel7-releng"){ 
+		withCredentials([string(credentialsId: 'codeready-bot', variable: 'GITHUB_TOKEN')]) { 
+			stage "Build ${CTL_path}"
+			cleanWs()
+			checkout([$class: 'GitSCM', 
+				branches: [[name: "${branchToBuildCTL}"]], 
+				doGenerateSubmoduleConfigurations: false, 
+				poll: true,
+				extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: "${CTL_path}"]], 
+				submoduleCfg: [], 
+				userRemoteConfigs: [[url: "https://github.com/redhat-developer/${CTL_path}.git"]]])
+			installNPM()
+			def CURRENT_DAY=sh(returnStdout:true,script:"date +'%Y%m%d'").trim()
+			def SHORT_SHA1=sh(returnStdout:true,script:"cd ${CTL_path}/ && git rev-parse --short HEAD").trim()
+			def CHECTL_VERSION="0.0.$CURRENT_DAY-next"
+			def GITHUB_RELEASE_NAME="0.0.$CURRENT_DAY-next.${SHORT_SHA1}"
+			def CUSTOM_TAG=sh(returnStdout:true,script:"date +'%Y%m%d%H%M%S'").trim()
+			SHA_CTL = sh(returnStdout:true,script:"cd ${CTL_path}/ && git rev-parse --short=4 HEAD").trim()
+			sh "cd ${CTL_path}/ && sed -i -e 's#version\": \"\\(.*\\)\",#version\": \"'${CHECTL_VERSION}'\",#' package.json"
+			sh "cd ${CTL_path}/ && egrep -v 'versioned|oclif' package.json | grep -e version"
+			sh "cd ${CTL_path}/ && git tag '${CUSTOM_TAG}'"
+			sh "rm ${CTL_path}/yarn.lock"
+			// remove windows 7z if installed
+			sh "rm -fr ${nodePath}/lib/node_modules/7zip"
+			// link to rpm-installed p7zip
+			sh "if [[ -x /usr/bin/7za ]]; then pushd ${nodePath}/bin >/dev/null; rm -f 7z*; ln -s /usr/bin/7za 7z; popd >/dev/null; fi"
+			sh "cd ${CTL_path}/ && yarn && npx oclif-dev pack -t ${platforms} && find ./dist/ -name \"*.tar*\""
+			def RELEASE_DESCRIPTION="CI release ${GITHUB_RELEASE_NAME}"
+			sh "curl -XPOST -H 'Authorization:token ${GITHUB_TOKEN}' --data '{\"tag_name\": \"${CUSTOM_TAG}\", \"target_commitish\": \"master\", \"name\": \"${GITHUB_RELEASE_NAME}\", \"body\": \"${RELEASE_DESCRIPTION}\", \"draft\": false, \"prerelease\": true}' https://api.github.com/repos/redhat-developer/codeready-workspaces-chectl/releases > /tmp/${CUSTOM_TAG}"
+			// Extract the id of the release from the creation response
+			def RELEASE_ID=sh(returnStdout:true,script:"jq -r .id /tmp/${CUSTOM_TAG}").trim()
+			// Upload the artifacts
+			sh "cd ${CTL_path}/dist/channels/next/ && curl -XPOST -H 'Authorization:token ${GITHUB_TOKEN}' -H 'Content-Type:application/octet-stream' --data-binary @crwctl-linux-x64.tar.gz https://uploads.github.com/repos/redhat-developer/codeready-workspaces-chectl/releases/${RELEASE_ID}/assets?name=crwctl-linux-x64.tar.gz"
+			sh "cd ${CTL_path}/dist/channels/next/ && curl -XPOST -H 'Authorization:token ${GITHUB_TOKEN}' -H 'Content-Type:application/octet-stream' --data-binary @crwctl-win32-x64.tar.gz https://uploads.github.com/repos/redhat-developer/codeready-workspaces-chectl/releases/${RELEASE_ID}/assets?name=crwctl-win32-x64.tar.gz"
+			sh "cd ${CTL_path}/dist/channels/next/ && curl -XPOST -H 'Authorization:token ${GITHUB_TOKEN}' -H 'Content-Type:application/octet-stream' --data-binary @crwctl-darwin-x64.tar.gz https://uploads.github.com/repos/redhat-developer/codeready-workspaces-chectl/releases/${RELEASE_ID}/assets?name=crwctl-darwin-x64.tar.gz"
+			// refresh github pages
+			sh "cd ${CTL_path}/ && git clone https://devstudio-release:${GITHUB_TOKEN}@github.com/redhat-developer/codeready-workspaces-chectl -b gh-pages --single-branch gh-pages"
+			sh "cd ${CTL_path}/ && echo \$(date +%s) > gh-pages/update"
+			sh "cd ${CTL_path}/gh-pages && git add update && git commit -m \"Update github pages\" && git push origin gh-pages"
+			archiveArtifacts fingerprint: false, artifacts:"**/*.log, **/*logs/**, **/dist/**/*.tar.gz, **/dist/*.json, **/dist/linux-x64, **/dist/win32-x64, **/dist/darwin-x64"
+		}
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,7 @@ def installNPM(){
 	sh "node --version && npm version && yarn -v"
 }
 
-// TODO: re-add win-x64; fails due to missing 7zip: "Error: install 7-zip to package windows tarball"
-def platforms = "linux-x64,darwin-x64,linux-arm"
+def platforms = "linux-x64,darwin-x64,win-x64"
 def CTL_path = "codeready-workspaces-chectl"
 def SHA_CTL = "SHA_CTL"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,7 +1368,7 @@ code-point-at@^1.0.0:
 
 "codeready-workspaces-operator@git://github.com/redhat-developer/codeready-workspaces-operator#master":
   version "0.0.0"
-  resolved "git://github.com/redhat-developer/codeready-workspaces-operator#cf4d5d10f2089dd2defdc1d6f881f7f011582fa7"
+  resolved "git://github.com/redhat-developer/codeready-workspaces-operator#d87e4ad4ed53f609ccd2a646e3582a47e5f678fb"
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* drop linux-arm build (never needed it)
* re-add win32-x64; now that we have p7zip installed on crw ci slaves
* remove unneeded stash/unstash step
* reformatting/line joins/whitespace fixes (view PR https://github.com/redhat-developer/codeready-workspaces-chectl/pull/17/files?w=1 to see minimal changeset, ignoring whitespace/indent changes)

Change-Id: I9d80896f4b9bc77559e5bf2094a0ef13a47da4d1
Signed-off-by: nickboldt <nboldt@redhat.com>