### PR TITLE
Fix default namespace name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ OPTIONS
   --che-operator-image=che-operator-image      [default: quay.io/crw/operator-rhel8:2.0] Container image of the
                                                operator. This parameter is used only when the installer is the operator
 
-  --deployment-name=deployment-name            [default: codeready] CodeReady Workspaces deployment name
+  --deployment-name=deployment-name            [default: workspaces] CodeReady Workspaces deployment name
 
   --devfile-registry-url=devfile-registry-url  The URL of the external Devfile registry.
 
@@ -238,7 +238,7 @@ OPTIONS
   --che-selector=che-selector              [default: app=che,component=che] Selector for CodeReady Workspaces Server
                                            resources
 
-  --deployment-name=deployment-name        [default: codeready] CodeReady Workspaces deployment name
+  --deployment-name=deployment-name        [default: workspaces] CodeReady Workspaces deployment name
 
   --listr-renderer=default|silent|verbose  [default: default] Listr renderer
 ```
@@ -268,7 +268,7 @@ OPTIONS
   --che-operator-image=che-operator-image  [default: quay.io/crw/operator-rhel8:2.0] Container image of the operator.
                                            This parameter is used only when the installer is the operator
 
-  --deployment-name=deployment-name        [default: codeready] CodeReady Workspaces deployment name
+  --deployment-name=deployment-name        [default: workspaces] CodeReady Workspaces deployment name
 
   --listr-renderer=default|silent|verbose  [default: default] Listr renderer
 


### PR DESCRIPTION
### What does this PR do?
It fixes default namespace from `codeready` to `workspaces`, as it was defined in https://github.com/redhat-developer/codeready-workspaces-chectl/blob/f22dc6bd5a5070690b0324243caa4c8348b235ad/src/common-flags.ts#L15
