### PR TITLE
Use registry.redhat.io to load server and operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ coverage
 .vscode
 bin/crwctl-*
 tsconfig.tsbuildinfo
+.idea
 # k8s templates are added at post-install step
 templates/codeready-workspaces-operator

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ OPTIONS
 
   -h, --help                                   show CLI help
 
-  -i, --cheimage=cheimage                      [default: quay.io/crw/server-rhel8:2.0] CodeReady Workspaces server
-                                               container image
+  -i, --cheimage=cheimage                      [default: registry.redhat.io/codeready-workspaces/server-rhel8:2.0]
+                                               CodeReady Workspaces server container image
 
   -m, --multiuser                              Starts CodeReady Workspaces in multi-user mode
 
@@ -194,8 +194,10 @@ OPTIONS
   --che-operator-cr-yaml=che-operator-cr-yaml  Path to a yaml file that defines a CheCluster used by the operator. This
                                                parameter is used only when the installer is the operator.
 
-  --che-operator-image=che-operator-image      [default: quay.io/crw/operator-rhel8:2.0] Container image of the
-                                               operator. This parameter is used only when the installer is the operator
+  --che-operator-image=che-operator-image      [default:
+                                               registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0]
+                                               Container image of the operator. This parameter is used only when the
+                                               installer is the operator
 
   --deployment-name=deployment-name            [default: codeready] CodeReady Workspaces deployment name
 
@@ -265,8 +267,9 @@ OPTIONS
 
   -t, --templates=templates                [default: templates] Path to the templates folder
 
-  --che-operator-image=che-operator-image  [default: quay.io/crw/operator-rhel8:2.0] Container image of the operator.
-                                           This parameter is used only when the installer is the operator
+  --che-operator-image=che-operator-image  [default: registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0]
+                                           Container image of the operator. This parameter is used only when the
+                                           installer is the operator
 
   --deployment-name=deployment-name        [default: codeready] CodeReady Workspaces deployment name
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ OPTIONS
 
   -h, --help                                   show CLI help
 
-  -i, --cheimage=cheimage                      [default: quay.io/crw/server-rhel8:2.0] CodeReady Workspaces server
+  -i, --cheimage=cheimage                      [default: registry.redhat.io/codeready-workspaces/server-rhel8:2.0] CodeReady Workspaces server
                                                container image
 
   -m, --multiuser                              Starts CodeReady Workspaces in multi-user mode
@@ -194,7 +194,7 @@ OPTIONS
   --che-operator-cr-yaml=che-operator-cr-yaml  Path to a yaml file that defines a CheCluster used by the operator. This
                                                parameter is used only when the installer is the operator.
 
-  --che-operator-image=che-operator-image      [default: quay.io/crw/operator-rhel8:2.0] Container image of the
+  --che-operator-image=che-operator-image      [default: registry.redhat.io/codeready-workspaces/operator-rhel8:2.0] Container image of the
                                                operator. This parameter is used only when the installer is the operator
 
   --deployment-name=deployment-name            [default: codeready] CodeReady Workspaces deployment name
@@ -265,7 +265,7 @@ OPTIONS
 
   -t, --templates=templates                [default: templates] Path to the templates folder
 
-  --che-operator-image=che-operator-image  [default: quay.io/crw/operator-rhel8:2.0] Container image of the operator.
+  --che-operator-image=che-operator-image  [default: registry.redhat.io/codeready-workspaces/operator-rhel8:2.0] Container image of the operator.
                                            This parameter is used only when the installer is the operator
 
   --deployment-name=deployment-name        [default: codeready] CodeReady Workspaces deployment name

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ OPTIONS
 
   -h, --help                                   show CLI help
 
-  -i, --cheimage=cheimage                      [default: registry.redhat.io/codeready-workspaces/server-rhel8:2.0] CodeReady Workspaces server
+  -i, --cheimage=cheimage                      [default: quay.io/crw/server-rhel8:2.0] CodeReady Workspaces server
                                                container image
 
   -m, --multiuser                              Starts CodeReady Workspaces in multi-user mode
@@ -194,7 +194,7 @@ OPTIONS
   --che-operator-cr-yaml=che-operator-cr-yaml  Path to a yaml file that defines a CheCluster used by the operator. This
                                                parameter is used only when the installer is the operator.
 
-  --che-operator-image=che-operator-image      [default: registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0] Container image of the
+  --che-operator-image=che-operator-image      [default: quay.io/crw/operator-rhel8:2.0] Container image of the
                                                operator. This parameter is used only when the installer is the operator
 
   --deployment-name=deployment-name            [default: codeready] CodeReady Workspaces deployment name
@@ -265,7 +265,7 @@ OPTIONS
 
   -t, --templates=templates                [default: templates] Path to the templates folder
 
-  --che-operator-image=che-operator-image  [default: registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0] Container image of the operator.
+  --che-operator-image=che-operator-image  [default: quay.io/crw/operator-rhel8:2.0] Container image of the operator.
                                            This parameter is used only when the installer is the operator
 
   --deployment-name=deployment-name        [default: codeready] CodeReady Workspaces deployment name

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ OPTIONS
   --che-operator-cr-yaml=che-operator-cr-yaml  Path to a yaml file that defines a CheCluster used by the operator. This
                                                parameter is used only when the installer is the operator.
 
-  --che-operator-image=che-operator-image      [default: registry.redhat.io/codeready-workspaces/operator-rhel8:2.0] Container image of the
+  --che-operator-image=che-operator-image      [default: registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0] Container image of the
                                                operator. This parameter is used only when the installer is the operator
 
   --deployment-name=deployment-name            [default: codeready] CodeReady Workspaces deployment name
@@ -265,7 +265,7 @@ OPTIONS
 
   -t, --templates=templates                [default: templates] Path to the templates folder
 
-  --che-operator-image=che-operator-image  [default: registry.redhat.io/codeready-workspaces/operator-rhel8:2.0] Container image of the operator.
+  --che-operator-image=che-operator-image  [default: registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0] Container image of the operator.
                                            This parameter is used only when the installer is the operator
 
   --deployment-name=deployment-name        [default: codeready] CodeReady Workspaces deployment name

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -14,7 +14,7 @@ components:
 
   - alias: dev
     type: dockerimage
-    image: quay.io/crw/theia-dev-rhel8:latest
+    image: registry.redhat.io/codeready-workspaces/theia-dev-rhel8:2.0
     mountSources: true
     memoryLimit: 3G
 
@@ -59,7 +59,7 @@ commands:
                  ./run devfile:generate \
                      --name=crwctl-test \
                      --language=typescript \
-                     --dockerimage=quay.io/crw/theia-dev-rhel8:latest \
+                     --dockerimage=registry.redhat.io/codeready-workspaces/theia-dev-rhel8:2.0 \
                      --git-repo=https://github.com/redhat-developer/codeready-workspaces-chectl.git \
                      --command="yarn" > /projects/sample.devfile;
                   cat /projects/sample.devfile

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-const DEFAULT_CHE_IMAGE = 'quay.io/crw/server-rhel8:2.0'
-const DEFAULT_CHE_OPERATOR_IMAGE = 'quay.io/crw/operator-rhel8:2.0'
+const DEFAULT_CHE_IMAGE = 'registry.redhat.io/codeready-workspaces/server-rhel8:2.0'
+const DEFAULT_CHE_OPERATOR_IMAGE = 'registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0'
 
 export { DEFAULT_CHE_IMAGE, DEFAULT_CHE_OPERATOR_IMAGE }


### PR DESCRIPTION
Fix default operator and server addresses to use **registry.redhat.io** instead of **quay.io** by default.

#### Issue to be fixed
https://issues.jboss.org/browse/CRW-506


