### PR TITLE
DO NOT MERGE: switch to latest 2.1-x tags in...

### DIFF
--- a/docs/custom-resource-minimal.yaml
+++ b/docs/custom-resource-minimal.yaml
@@ -1,0 +1,35 @@
+apiVersion: org.eclipse.che/v1
+kind: CheCluster
+metadata:
+  name: codeready-workspaces
+spec:
+  server:
+    # operator is quay.io/crw/operator-rhel8:2.1-5
+    cheImage: 'quay.io/crw/server-rhel8'
+    cheImageTag: '2.1-5'
+    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-10'
+    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1-40'
+    cheFlavor: 'codeready'
+    selfSignedCert: true
+    tlsSupport: true
+    # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties and
+    # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
+    customCheProperties:	
+      # CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
+      # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
+      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-3'
+      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-3'
+      CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1-7'
+      CHE_FACTORY_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
+      CHE_FACTORY_DEFAULT__PLUGINS: 'eclipse/che-machine-exec-plugin/latest'
+      CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
+      CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR_PLUGINS: 'eclipse/che-machine-exec-plugin/latest'
+    
+  storage:
+    # see https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties#L266
+    pvcStrategy: 'common'
+
+  auth:
+    identityProviderAdminUserName: 'admin'
+    identityProviderPassword: 'admin'
+    openShiftoAuth: true

--- a/docs/custom-resource-minimal.yaml
+++ b/docs/custom-resource-minimal.yaml
@@ -15,7 +15,7 @@ spec:
     # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties and
     # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
     customCheProperties:	
-      # CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
+      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
       CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-3'
       CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-3'

--- a/docs/custom-resource-minimal.yaml
+++ b/docs/custom-resource-minimal.yaml
@@ -4,22 +4,26 @@ metadata:
   name: codeready-workspaces
 spec:
   server:
-    # operator is quay.io/crw/operator-rhel8:2.1-12
+    # operator is quay.io/crw/operator-rhel8:2.1
     cheImage: 'quay.io/crw/server-rhel8'
-    cheImageTag: '2.1-6'
-    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-16'
-    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1-44'
+    cheImageTag: '2.1'
+    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1'
+    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1'
     cheFlavor: 'codeready'
     selfSignedCert: true
     tlsSupport: true
     # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties and
     # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
-    customCheProperties:	
+    customCheProperties:
+      CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY: 'Always'
       CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
+      CHE_INFRA_KUBERNETES_WORKSPACE__UNRECOVERABLE__EVENTS: 'Failed Scheduling,Failed to pull image'
+      CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
+      # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
-      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-5'
-      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-5'
-      CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1-7'
+      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1'
+      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1'
+      CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1'
       CHE_FACTORY_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
       CHE_FACTORY_DEFAULT__PLUGINS: 'eclipse/che-machine-exec-plugin/latest'
       CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR: 'eclipse/che-theia/latest'

--- a/docs/custom-resource-minimal.yaml
+++ b/docs/custom-resource-minimal.yaml
@@ -4,11 +4,11 @@ metadata:
   name: codeready-workspaces
 spec:
   server:
-    # operator is quay.io/crw/operator-rhel8:2.1-5
+    # operator is quay.io/crw/operator-rhel8:2.1-12
     cheImage: 'quay.io/crw/server-rhel8'
     cheImageTag: '2.1-6'
-    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-10'
-    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1-40'
+    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-16'
+    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1-44'
     cheFlavor: 'codeready'
     selfSignedCert: true
     tlsSupport: true
@@ -17,8 +17,8 @@ spec:
     customCheProperties:	
       CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
-      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-4'
-      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-4'
+      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-5'
+      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-5'
       CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1-7'
       CHE_FACTORY_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
       CHE_FACTORY_DEFAULT__PLUGINS: 'eclipse/che-machine-exec-plugin/latest'

--- a/docs/custom-resource-minimal.yaml
+++ b/docs/custom-resource-minimal.yaml
@@ -27,7 +27,8 @@ spec:
     
   storage:
     # see https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties#L266
-    pvcStrategy: 'common'
+    # set to per-workspace for CRW (required for OSD), set to common for Che.
+    pvcStrategy: 'per-workspace'
 
   auth:
     identityProviderAdminUserName: 'admin'

--- a/docs/custom-resource-minimal.yaml
+++ b/docs/custom-resource-minimal.yaml
@@ -6,7 +6,7 @@ spec:
   server:
     # operator is quay.io/crw/operator-rhel8:2.1-5
     cheImage: 'quay.io/crw/server-rhel8'
-    cheImageTag: '2.1-5'
+    cheImageTag: '2.1-6'
     devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-10'
     pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1-40'
     cheFlavor: 'codeready'
@@ -17,8 +17,8 @@ spec:
     customCheProperties:	
       CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
-      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-3'
-      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-3'
+      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-4'
+      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-4'
       CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1-7'
       CHE_FACTORY_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
       CHE_FACTORY_DEFAULT__PLUGINS: 'eclipse/che-machine-exec-plugin/latest'

--- a/docs/custom-resource.yaml
+++ b/docs/custom-resource.yaml
@@ -4,15 +4,15 @@ metadata:
   name: codeready-workspaces
 spec:
   server:
-    # operator is quay.io/crw/operator-rhel8:2.1-5
+    # operator is quay.io/crw/operator-rhel8:2.1-12
     # server image used in Che deployment
     cheImage: 'quay.io/crw/server-rhel8'
     # tag of an image used in Che deployment
     cheImageTag: '2.1-6'
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-10'
+    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-16'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1-40'
+    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1-44'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: 'codeready'
@@ -47,8 +47,8 @@ spec:
       # CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
       # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
-      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-4'
-      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-4'
+      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-5'
+      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-5'
       CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1-7'
       CHE_FACTORY_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
       CHE_FACTORY_DEFAULT__PLUGINS: 'eclipse/che-machine-exec-plugin/latest'

--- a/docs/custom-resource.yaml
+++ b/docs/custom-resource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: codeready-workspaces
 spec:
   server:
-    # operator is quay.io/crw/operator-rhel8:2.1-9
+    # operator is quay.io/crw/operator-rhel8:2.1-5
     # server image used in Che deployment
     cheImage: 'quay.io/crw/server-rhel8'
     # tag of an image used in Che deployment
@@ -42,9 +42,9 @@ spec:
     # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties and
     # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
     customCheProperties:	
-      CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY: 'Always'
-      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
-      CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
+      # CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY: 'Always'
+      # CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
+      # CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
       # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
       CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-3'
@@ -73,9 +73,8 @@ spec:
     # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
     postgresImage: ''
   storage:
-    # persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),
-    # per-workspace (one PVC per workspace for all declared volumes) and unique (one PVC per declared volume). Defaults to common
-    pvcStrategy: 'per-workspace'
+    # see https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties#L266
+    pvcStrategy: 'common'
     # size of a persistent volume claim for workspaces. Defaults to 1Gi
     pvcClaimSize: '1Gi'
     # instruct Che server to launch a special pod to precreate a subpath in a PV

--- a/docs/custom-resource.yaml
+++ b/docs/custom-resource.yaml
@@ -43,7 +43,7 @@ spec:
     # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
     customCheProperties:	
       # CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY: 'Always'
-      # CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
+      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
       # CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
       # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'

--- a/docs/custom-resource.yaml
+++ b/docs/custom-resource.yaml
@@ -8,7 +8,7 @@ spec:
     # server image used in Che deployment
     cheImage: 'quay.io/crw/server-rhel8'
     # tag of an image used in Che deployment
-    cheImageTag: '2.1-5'
+    cheImageTag: '2.1-6'
     # image:tag used in Devfile registry deployment
     devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-10'
     # image:tag used in plugin registry deployment
@@ -47,8 +47,8 @@ spec:
       # CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
       # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
-      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-3'
-      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-3'
+      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-4'
+      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-4'
       CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1-7'
       CHE_FACTORY_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
       CHE_FACTORY_DEFAULT__PLUGINS: 'eclipse/che-machine-exec-plugin/latest'

--- a/docs/custom-resource.yaml
+++ b/docs/custom-resource.yaml
@@ -4,14 +4,15 @@ metadata:
   name: codeready-workspaces
 spec:
   server:
+    # operator is quay.io/crw/operator-rhel8:2.1-9
     # server image used in Che deployment
     cheImage: 'quay.io/crw/server-rhel8'
     # tag of an image used in Che deployment
-    cheImageTag: 'latest'
+    cheImageTag: '2.1-5'
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:latest'
+    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-10'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:latest'
+    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1-40'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: 'codeready'
@@ -46,9 +47,9 @@ spec:
       CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
       # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
-      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:latest'
-      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:latest'
-      CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:latest'
+      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-3'
+      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-3'
+      CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1-7'
       CHE_FACTORY_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
       CHE_FACTORY_DEFAULT__PLUGINS: 'eclipse/che-machine-exec-plugin/latest'
       CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR: 'eclipse/che-theia/latest'

--- a/docs/custom-resource.yaml
+++ b/docs/custom-resource.yaml
@@ -4,15 +4,15 @@ metadata:
   name: codeready-workspaces
 spec:
   server:
-    # operator is quay.io/crw/operator-rhel8:2.1-12
+    # operator is quay.io/crw/operator-rhel8:2.1
     # server image used in Che deployment
     cheImage: 'quay.io/crw/server-rhel8'
     # tag of an image used in Che deployment
-    cheImageTag: '2.1-6'
+    cheImageTag: '2.1'
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1-16'
+    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.1'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1-44'
+    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.1'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: 'codeready'
@@ -21,7 +21,10 @@ spec:
     cheWorkspaceClusterRole: ''
     # when set to true the operator will attempt to get a secret in OpenShift router namespace
     # to add it to Java trust store of Che server. Requires cluster-admin privileges for operator service account
-    selfSignedCert: true
+    selfSignedCert: false
+    ## If enabled then the certificate from `che-git-self-signed-cert` config map
+    ## will be propagated to the Che components and provide particular configuration for Git.
+    gitSelfSignedCert: false
     # TLS mode for Che. Make sure you either have public cert, or set selfSignedCert to true
     tlsSupport: true
     # protocol+hostname of a proxy server. Automatically added as JAVA_OPTS and https(s)_proxy
@@ -39,22 +42,27 @@ spec:
     serverMemoryRequest: ''
     # sets mem limit for server deployment. Defaults to 1Gi
     serverMemoryLimit: ''
+    # sets default namespace where new workspaces will be created
+    workspaceNamespaceDefault: ''
+    # defines if user is able to specify namespace different from the default
+    allowUserDefinedWorkspaceNamespaces: false
     # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties and
     # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
-    customCheProperties:	
-      # CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY: 'Always'
+    customCheProperties:
+      CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY: 'Always'
       CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
-      # CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
+      CHE_INFRA_KUBERNETES_WORKSPACE__UNRECOVERABLE__EVENTS: 'Failed Scheduling,Failed to pull image'
+      CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
       # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
       # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0'
-      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1-5'
-      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1-5'
-      CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1-7'
+      CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE: 'quay.io/crw/pluginbroker-metadata-rhel8:2.1'
+      CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE: 'quay.io/crw/pluginbroker-artifacts-rhel8:2.1'
+      CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.1'
       CHE_FACTORY_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
       CHE_FACTORY_DEFAULT__PLUGINS: 'eclipse/che-machine-exec-plugin/latest'
       CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR: 'eclipse/che-theia/latest'
       CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR_PLUGINS: 'eclipse/che-machine-exec-plugin/latest'
-    
+
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created
@@ -113,3 +121,7 @@ spec:
     # image:tag used in Keycloak deployment
     # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
     identityProviderImage: ''
+  
+  metrics:
+    # Enables '/metrics' endpoint of Che server.
+    enable: false

--- a/docs/custom-resource.yaml
+++ b/docs/custom-resource.yaml
@@ -74,7 +74,8 @@ spec:
     postgresImage: ''
   storage:
     # see https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties#L266
-    pvcStrategy: 'common'
+    # set to per-workspace for CRW (required for OSD), set to common for Che.
+    pvcStrategy: 'per-workspace'
     # size of a persistent volume claim for workspaces. Defaults to 1Gi
     pvcClaimSize: '1Gi'
     # instruct Che server to launch a special pod to precreate a subpath in a PV


### PR DESCRIPTION
DO NOT MERGE: switch to latest 2.1-x tags in a branch so we can more easily pick the latest actual images (and avoid image caching inside OCP)

Change-Id: I88c615ed3ed1a98460b27d5ea681aa232679e166
Signed-off-by: nickboldt <nboldt@redhat.com>