### PR TITLE
Reuse OLM installer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/request": "^2.48.4",
     "@types/websocket": "^1.0.0",
     "@types/ws": "^7.2.1",
+    "ansi-colors": "4.1.1",
     "axios": "^0.19.0",
     "cli-ux": "^5.4.4",
     "codeready-workspaces-operator": "git://github.com/redhat-developer/codeready-workspaces-operator#master",

--- a/sync-chectl-to-crwctl.sh
+++ b/sync-chectl-to-crwctl.sh
@@ -55,13 +55,22 @@ pushd "${SOURCEDIR}" >/dev/null
 			-e "s|resource: Kubernetes/OpenShift/Helm|resource|g" \
 			-e "/import \{ HelmTasks \} from '..\/..\/tasks\/installers\/helm'/d" \
 			-e "/import \{ MinishiftAddonTasks \} from '..\/..\/tasks\/installers\/minishift-addon'/d" \
-			-e "/    const helmTasks = new HelmTasks\(\)/d" \
-			\
+			-e "/    const helmTasks = new HelmTasks\(flags\)/d" \
 			-e "/    const (minishiftAddonTasks|msAddonTasks) = new MinishiftAddonTasks\(\)/d" \
 			-e '/.+tasks.add\(helmTasks.+/d' \
 			-e '/.+tasks.add\((minishiftAddonTasks|msAddonTasks).+/d' \
 			-e "s|(const DEFAULT_CHE_IMAGE =).+|\1 'registry.redhat.io/codeready-workspaces/server-rhel8:${CRW_SERVER_TAG}'|g" \
 			-e "s|(const DEFAULT_CHE_OPERATOR_IMAGE =).+|\1 'registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:${CRW_OPERATOR_TAG}'|g" \
+			\
+			-e "s|(const CHE_CLUSTER_CR_NAME =).+|\1 'codeready-workspaces'|g" \
+			\
+			-e "s|(const DEFAULT_CHE_OLM_PACKAGE_NAME =).+|\1 'codeready-workspaces'|g" \
+			-e "s|(const OLM_STABLE_CHANNEL_NAME =).+|\1 'latest'|g" \
+			-e "s|(const CUSTOM_CATALOG_SOURCE_NAME =).+|\1 'codeready-custom-catalog-source'|g" \
+			-e "s|(const SUBSCRIPTION_NAME =).+|\1 'codeready-subscription'|g" \
+			-e "s|(const OPERATOR_GROUP_NAME =).+|\1 'codeready-operator-group'|g" \
+			-e "s|(const OPENSHIFT_OLM_CATALOG =).+|\1 'redhat-operators'|g" \
+			-e "s|(CVS_PREFIX =).+|\1 'crwoperator'|g" \
 			\
 			-e "s|\"CodeReady Workspaces will be deployed in Multi-User mode.+mode.\"|'CodeReady Workspaces can only be deployed in Multi-User mode.'|" \
 			-e "s|che-incubator/crwctl|redhat-developer/codeready-workspaces-chectl|g" \
@@ -89,7 +98,7 @@ platformString="    platform: string({\n\
 installerString="    installer: string({\n\
       char: 'a',\n\
       description: 'Installer type',\n\
-      options: ['operator'],\n\
+      options: ['operator', 'olm'],\n\
       default: 'operator'\n\
     }),"; # echo -e "$installerString"
 setPlaformDefaultsString="  static setPlaformDefaults(flags: any) {\n\

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,6 +746,11 @@ ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ansi-colors@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+
 ansi-escapes@^3.0.0, ansi-escapes@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -1362,7 +1367,7 @@ code-point-at@^1.0.0:
 
 "codeready-workspaces-operator@git://github.com/redhat-developer/codeready-workspaces-operator#master":
   version "0.0.0"
-  resolved "git://github.com/redhat-developer/codeready-workspaces-operator#20b9bdbd70e8d06ea8a27868561d990e18d5d836"
+  resolved "git://github.com/redhat-developer/codeready-workspaces-operator#98ca9f102354bf8fd047a5a27517af0e19247136"
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What does this PR do?
Reuse OLM installer.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16862

### Depends on:
https://github.com/che-incubator/chectl/pull/724

### How to test:

```shell
# Generate files update.
$ ./sync-chectl-to-crwctl.sh /home/user/projects/chectl/ /home/user/codeready-workspaces-chectl/ 2.2.0 2.2.0

$ cd bin

# Install CodeReady with specific version:
$ ./run server:start -a olm -n moon45 --starting-csv crwoperator.v2.1.0  --self-signed-cert

# Update CodeReady:
$ ./run server:update -a olm -n moon45

# Uninstall:
$ ./run server:delete -n moon45
```

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>