### PR TITLE
Enable default installer detection

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -98,8 +98,7 @@ export default class Start extends Command {
     installer: string({
       char: 'a',
       description: 'Installer type',
-      options: ['operator', 'olm'],
-      default: 'operator'
+      options: ['operator', 'olm']
     }),
     domain: string({
       char: 'b',

--- a/sync-chectl-to-crwctl.sh
+++ b/sync-chectl-to-crwctl.sh
@@ -97,7 +97,7 @@ platformString="    platform: string({\n\
     }),"; # echo -e "$platformString"
 installerString="    installer: string({\n\
       char: 'a',\n\
-      description: 'Installer type - will be automatically detected depending on your target platform',\n\
+      description: 'Installer type - if OLM installed in cluster, use olm install method; else use deprecated operator method',\n\
       options: ['operator', 'olm'],\n\
     }),"; # echo -e "$installerString"
 setPlaformDefaultsString="  static setPlaformDefaults(flags: any) {\n\

--- a/sync-chectl-to-crwctl.sh
+++ b/sync-chectl-to-crwctl.sh
@@ -97,7 +97,7 @@ platformString="    platform: string({\n\
     }),"; # echo -e "$platformString"
 installerString="    installer: string({\n\
       char: 'a',\n\
-      description: 'Installer type - if OLM installed in cluster, use olm install method; else use deprecated operator method',\n\
+      description: 'Installer type. If argument is not defined, then installer will be "olm" for OpenShift with version >= 4.2, otherwise "operator".',\n\
       options: ['operator', 'olm'],\n\
     }),"; # echo -e "$installerString"
 setPlaformDefaultsString="  static setPlaformDefaults(flags: any) {\n\

--- a/sync-chectl-to-crwctl.sh
+++ b/sync-chectl-to-crwctl.sh
@@ -97,7 +97,7 @@ platformString="    platform: string({\n\
     }),"; # echo -e "$platformString"
 installerString="    installer: string({\n\
       char: 'a',\n\
-      description: 'Installer type. If argument is not defined, then installer will be "olm" for OpenShift with version >= 4.2, otherwise "operator".',\n\
+      description: 'Installer type. If not set, default is "olm" for OpenShift >= 4.2, and "operator" for earlier versions.',\n\
       options: ['operator', 'olm'],\n\
     }),"; # echo -e "$installerString"
 setPlaformDefaultsString="  static setPlaformDefaults(flags: any) {\n\

--- a/sync-chectl-to-crwctl.sh
+++ b/sync-chectl-to-crwctl.sh
@@ -97,7 +97,7 @@ platformString="    platform: string({\n\
     }),"; # echo -e "$platformString"
 installerString="    installer: string({\n\
       char: 'a',\n\
-      description: 'Installer type',\n\
+      description: 'Installer type - will be automatically detected depending on your target platform',\n\
       options: ['operator', 'olm'],\n\
     }),"; # echo -e "$installerString"
 setPlaformDefaultsString="  static setPlaformDefaults(flags: any) {\n\

--- a/sync-chectl-to-crwctl.sh
+++ b/sync-chectl-to-crwctl.sh
@@ -99,7 +99,6 @@ installerString="    installer: string({\n\
       char: 'a',\n\
       description: 'Installer type',\n\
       options: ['operator', 'olm'],\n\
-      default: 'operator'\n\
     }),"; # echo -e "$installerString"
 setPlaformDefaultsString="  static setPlaformDefaults(flags: any) {\n\
     flags.installer = 'operator'\n\

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,6 +138,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@eclipse-che/api@latest":
+  version "7.5.0-SNAPSHOT"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.5.0-SNAPSHOT.tgz#bf0c5be60354e34c73bc52b2e18be8680ce8d900"
+  integrity sha512-4CgKEGCBOIOBGBNoH0dhN8TkP1Sj39fG4LGCXYw3JB7nQucVooJyq7AhIV+w7L4iZ+ln+y2KEfZugCmOIuzIeQ==
+
 "@fimbul/bifrost@^0.21.0":
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.21.0.tgz#d0fafa25938fda475657a6a1e407a21bbe02c74e"
@@ -1367,7 +1372,7 @@ code-point-at@^1.0.0:
 
 "codeready-workspaces-operator@git://github.com/redhat-developer/codeready-workspaces-operator#master":
   version "0.0.0"
-  resolved "git://github.com/redhat-developer/codeready-workspaces-operator#98ca9f102354bf8fd047a5a27517af0e19247136"
+  resolved "git://github.com/redhat-developer/codeready-workspaces-operator#ed63df5f162ef60d93099bb55347a37f35b41c64"
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What does this PR do?
Enable default installer detection. Use newer template folder for operator installer to update cluster permissions.

How installer detection works:
If user doesn't provide argument installer argument, then chectl checks if platform is openshift4. If true then installer will be olm, otherwise - operator.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-967

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

