### PR TITLE
Use catalog source by name.

### DIFF
--- a/src/commands/server/start.ts
+++ b/src/commands/server/start.ts
@@ -20,7 +20,7 @@ import * as path from 'path'
 
 import { KubeHelper } from '../../api/kube'
 import { cheDeployment, cheNamespace, listrRenderer, skipKubeHealthzCheck as skipK8sHealthCheck } from '../../common-flags'
-import { DEFAULT_CHE_IMAGE, DEFAULT_CHE_OPERATOR_IMAGE, DOCS_LINK_INSTALL_TLS_WITH_SELF_SIGNED_CERT } from '../../constants'
+import { DEFAULT_CHE_IMAGE, DEFAULT_CHE_OPERATOR_IMAGE, DOCS_LINK_INSTALL_TLS_WITH_SELF_SIGNED_CERT, OLM_STABLE_CHANNEL_NAME, DEFAULT_CHE_OLM_PACKAGE_NAME } from '../../constants'
 import { CheTasks } from '../../tasks/che'
 import { getPrintHighlightedMessagesTask, getRetrieveKeycloakCredentialsTask, retrieveCheCaCertificateTask } from '../../tasks/installers/common-tasks'
 import { InstallerTasks } from '../../tasks/installers/installer'
@@ -174,18 +174,26 @@ export default class Start extends Command {
       description: `Olm channel to install CodeReady Workspaces, f.e. stable.
                     If options was not set, will be used default version for package manifest.
                     This parameter is used only when the installer is the 'olm'.`,
-      dependsOn: ['catalog-source-yaml']
+      default: OLM_STABLE_CHANNEL_NAME
     }),
     'package-manifest-name': string({
       description: `Package manifest name to subscribe to CodeReady Workspaces OLM package manifest.
                     This parameter is used only when the installer is the 'olm'.`,
-      dependsOn: ['catalog-source-yaml']
+      default: DEFAULT_CHE_OLM_PACKAGE_NAME
     }),
     'catalog-source-yaml': string({
       description: `Path to a yaml file that describes custom catalog source for installation CodeReady Workspaces operator.
                     Catalog source will be applied to the namespace with Che operator.
                     Also you need define 'olm-channel' name and 'package-manifest-name'.
                     This parameter is used only when the installer is the 'olm'.`,
+    }),
+    'catalog-source-name': string({
+      description: `OLM catalog source to install CodeReady Workspaces operator.
+                    This parameter is used only when the installer is the 'olm'.`
+    }),
+    'catalog-source-namespace': string({
+      description: `Namespace for OLM catalog source to install CodeReady Workspaces operator.
+                    This parameter is used only when the installer is the 'olm'.`
     }),
     'skip-kubernetes-health-check': skipK8sHealthCheck
   }
@@ -300,18 +308,20 @@ export default class Start extends Command {
       if (flags.installer !== 'olm' && flags['catalog-source-yaml']) {
         this.error('"catalog-source-yaml" flag should be used only with "olm" installer.')
       }
+      if (flags.installer !== 'olm' && flags['catalog-source-name']) {
+        this.error('"catalog-source-name" flag should be used only with "olm" installer.')
+      }
+      if (flags['catalog-source-name'] && flags['catalog-source-yaml']) {
+        this.error('should be provided only one argument: "catalog-source-name" or "catalog-source-yaml"')
+      }
       if (flags.installer !== 'olm' && flags['olm-channel']) {
         this.error('"olm-channel" flag should be used only with "olm" installer.')
       }
       if (flags.installer !== 'olm' && flags['package-manifest-name']) {
         this.error('"package-manifest-name" flag should be used only with "olm" installer.')
       }
-
-      if (!flags['package-manifest-name'] && flags['catalog-source-yaml']) {
-        this.error('you need define "package-manifest-name" flag to use "catalog-source-yaml".')
-      }
-      if (!flags['olm-channel'] && flags['catalog-source-yaml']) {
-        this.error('you need define "olm-channel" flag to use "catalog-source-yaml".')
+      if (flags.installer !== 'olm' && flags['catalog-source-namespace']) {
+        this.error('"package-manifest-name" flag should be used only with "olm" installer.')
       }
     }
   }

--- a/src/tasks/installers/olm.ts
+++ b/src/tasks/installers/olm.ts
@@ -52,7 +52,7 @@ export class OLMTasks {
 
           ctx.approvalStarategy = flags['auto-update'] ? 'Automatic' : 'Manual'
 
-          ctx.sourceName = CUSTOM_CATALOG_SOURCE_NAME
+          ctx.sourceName = flags['catalog-source-name'] || CUSTOM_CATALOG_SOURCE_NAME
 
           task.title = `${task.title}...done.`
         }
@@ -80,10 +80,11 @@ export class OLMTasks {
             task.title = `${task.title}...It already exists.`
           } else {
             let subscription: Subscription
-            if (!flags['catalog-source-yaml']) {
+            if (!flags['catalog-source-yaml'] && !flags['catalog-source-name']) {
               subscription = this.createSubscription(SUBSCRIPTION_NAME, DEFAULT_CHE_OLM_PACKAGE_NAME, flags.chenamespace, ctx.defaultCatalogSourceNamespace, OLM_STABLE_CHANNEL_NAME, ctx.catalogSourceNameStable, ctx.approvalStarategy, flags['starting-csv'])
             } else {
-              subscription = this.createSubscription(SUBSCRIPTION_NAME, flags['package-manifest-name'], flags.chenamespace, flags.chenamespace, flags['olm-channel'], ctx.sourceName, ctx.approvalStarategy, flags['starting-csv'])
+              const catalogSourceNamespace = flags['catalog-source-namespace'] || flags.chenamespace
+              subscription = this.createSubscription(SUBSCRIPTION_NAME, flags['package-manifest-name'], flags.chenamespace, catalogSourceNamespace, flags['olm-channel'], ctx.sourceName, ctx.approvalStarategy, flags['starting-csv'])
             }
             await kube.createOperatorSubscription(subscription)
             task.title = `${task.title}...created new one.`


### PR DESCRIPTION
### What does this PR do?
Earlier we have ability to use CatalogSource by yaml file. This pr provides way how to use already created CatalogSource by name(and namespace if it is differ, than target namespace for che installation).

**Advanced case (for testing RC):**
It can be also useful if you want to use OperatorSource with some test application registry . For example:

```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: codeready-test
spec:
  displayName: Custom Operators
  endpoint: https://quay.io/cnr
  publisher: Red Hat
  registryNamespace: crw
  type: appregistry
```
You applied it to the cluster:

```
$ kubectl apply -f operatorSource.yaml -n openshift-marketplace
```

Olm will create CatalogSource for this OperatorSource with the same name.
You can install CodeReady Che:

```
$ crwctl server:start -a olm -m -n moon45 --catalog-source-name=codeready-test --catalog-source-namespace=openshift-marketplace
```


### What issues does this PR fix or reference?
Proposal for discussion in the https://issues.redhat.com/browse/CRW-976

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>