### PR TITLE
Don't check version for crwctl during default installer detection

### DIFF
--- a/sync-chectl-to-crwctl.sh
+++ b/sync-chectl-to-crwctl.sh
@@ -43,6 +43,7 @@ pushd "${SOURCEDIR}" >/dev/null
 			-e "s|app=che|app=codeready|g" \
 			-e "s|app=codeready,component=che|app=codeready,component=codeready|" \
 			-e "s|che-operator|codeready-operator|g" \
+			-e "s| && isStableVersion\(flags\)||g" \
 			-e "s|/codeready-operator/|/codeready-workspaces-operator/|g" \
 			\
 			-e "s|codeready-operator-(cr.+yaml)|che-operator-\1|g" \


### PR DESCRIPTION
### What does this PR do?
Don't check version for crwctl during default installer detection, crwctl version is always stable(I mean, we don't have a nightly).

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-967

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>