### PR TITLE
CRW-1086 operatorCheCluster is now...

### DIFF
--- a/sync-chectl-to-crwctl.sh
+++ b/sync-chectl-to-crwctl.sh
@@ -50,7 +50,7 @@ pushd "${SOURCEDIR}" >/dev/null
 			-e "s|codeready-operator-(cr.+yaml)|che-operator-\1|g" \
 			-e "s|codeready-operator-(cr.+yaml)|che-operator-\1|g" \
 			-e "s|codeready-operator-image|che-operator-image|g" \
-			-e "s|operatorCheCluster = 'eclipse-che'|operatorCheCluster = 'codeready-workspaces'|g" \
+			-e "s|CHE_CLUSTER_CR_NAME = 'eclipse-che'|CHE_CLUSTER_CR_NAME = 'codeready-workspaces'|g" \
 			-e "s|Eclipse Che|CodeReady Workspaces|g" \
 			\
 			-e "s| when both minishift and OpenShift are stopped||" \


### PR DESCRIPTION
CRW-1086 operatorCheCluster is now CHE_CLUSTER_CR_NAME, so update sync script accordingly

Change-Id: If5de6b41e09fec864240bb493a6e8b2ea779d54e
Signed-off-by: nickboldt <nboldt@redhat.com>