### PR TITLE
Remove workspace:inject command from crwctl

### DIFF
--- a/sync-chectl-to-crwctl.sh
+++ b/sync-chectl-to-crwctl.sh
@@ -81,6 +81,16 @@ pushd "${SOURCEDIR}" >/dev/null
 	# TODO add package.json into the above?
 popd >/dev/null
 
+# Remove workspace commands
+pushd "${TARGETDIR}" >/dev/null
+    while IFS= read -r -d '' d; do
+        echo "[INFO] Delete ${d#./}"
+        rm -f "$d"
+        #
+    done <   <(find . -regextype posix-extended -iregex '.+/(inject|create|delete|list|logs|start|stop).ts' -print0)
+popd >/dev/null
+
+
 # Remove files
 pushd "${TARGETDIR}" >/dev/null
 	while IFS= read -r -d '' d; do


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Current Pull request  exclude some workspace:inject command.

### What issues does this PR fix or reference?
Refference issue: https://github.com/eclipse/che/issues/18070
