### PR TITLE
feat: Add telemetry to see target commands and platforms used by users

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,10 @@ def CTL_path = "codeready-workspaces-chectl"
 def SHA_CTL = "SHA_CTL"
 def GITHUB_RELEASE_NAME=""
 
+environment {
+    SEGMENT_WRITE_KEY = credentials('segment-write-key')
+}
+
 timeout(20) {
     node("${buildNode}"){
         stage "Checkout crw-operator deploy"
@@ -145,6 +149,7 @@ timeout(20) {
 			git diff -u package.json
 			git tag -f "''' + CUSTOM_TAG + '''-redhat"
 			rm -fr lib/ node_modules/ templates/ tmp/ tsconfig.tsbuildinfo dist/
+			sed -i "s|INSERT-KEY-HERE|$SEGMENT_WRITE_KEY|g" src/hooks/analytics/analytics.ts
 			yarn && npx oclif-dev pack -t ''' + platforms + '''
 			# move from *-redhat/ (specific folder, generic name) to redhat/ (generic folder, specific name)
 			mv dist/channels/*redhat dist/channels/redhat


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
This PR add segment key to our crwctl builds to enable telemetry.

Upstream PR: https://github.com/che-incubator/chectl/pull/1052
Upstream chectl build key: https://github.com/che-incubator/chectl/blob/master/.github/workflows/release-build-and-push-to-GH-releases.yml#L55
Related issue: https://github.com/eclipse/che/issues/18069

### What issues does this PR fix or reference?

