### PR TITLE
Use openshift-workspaces as a default namespace

### DIFF
--- a/build/scripts/sync-chectl-to-crwctl.sh
+++ b/build/scripts/sync-chectl-to-crwctl.sh
@@ -97,6 +97,8 @@ pushd "${SOURCEDIR}" >/dev/null
 			-e "s|(const OPERATOR_GROUP_NAME =).+|\1 'codeready-operator-group'|g" \
 			-e "s|(const OPENSHIFT_OLM_CATALOG =).+|\1 'redhat-operators'|g" \
 			-e "s|(const DEFAULT_OLM_SUGGESTED_NAMESPACE =).+|\1 'openshift-workspaces'|g" \
+			-e "s|(const DEFAULT_CHE_NAMESPACE =).+|\1 'openshift-workspaces'|g" \
+			-e "s|(const LEGACY_CHE_NAMESPACE =).+|\1 'workspaces'|g" \
 			-e "s|(CVS_PREFIX =).+|\1 'crwoperator'|g" \
 			\
 			-e "s|\"CodeReady Workspaces will be deployed in Multi-User mode.+mode.\"|'CodeReady Workspaces can only be deployed in Multi-User mode.'|" \
@@ -166,7 +168,6 @@ pushd "${TARGETDIR}" >/dev/null
 	sed -r \
 		`# replace line after specified one with new default` \
 		-e "s|Kubernetes namespace|Openshift Project|g" \
-		-e "/description: 'Openshift Project/{n;s/.+/  default: 'workspaces',/}" \
 		-e "/description: .+ deployment name.+/{n;s/.+/  default: 'codeready',/}" \
 		-i "${TARGETDIR}/${d}"
 popd >/dev/null


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

Can be merged after https://github.com/che-incubator/chectl/pull/1060

### What does this PR do?
Use openshift-workspacesd as a default namespace for both `--installer operator` and `--installer olm` types

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1476