### PR TITLE
fix: Add config files for eslint from chectl side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ bin/crwctl-*
 tsconfig.tsbuildinfo
 # templates are added at post-install step
 templates
-
+.eslintcache

--- a/build/scripts/sync-chectl-to-crwctl.sh
+++ b/build/scripts/sync-chectl-to-crwctl.sh
@@ -103,7 +103,7 @@ pushd "${SOURCEDIR}" >/dev/null
 			-e "s|\"CodeReady Workspaces will be deployed in Multi-User mode.+mode.\"|'CodeReady Workspaces can only be deployed in Multi-User mode.'|" \
 			-e "s|che-incubator/crwctl|redhat-developer/codeready-workspaces-chectl|g" \
 		"$d" > "${TARGETDIR}/${d}"
-	done <   <(find src test installers package.json .ci/obfuscate/gnirts.js -type f -name "*" -print0) # include package.json in here too
+	done <   <(find src test installers configs package.json .ci/obfuscate/gnirts.js .eslintrc.js  -type f -name "*" -print0) # include package.json in here too
 popd >/dev/null
 
 # Remove files
@@ -120,7 +120,7 @@ platformString="    platform: string({\n\
       char: 'p',\n\
       description: 'Type of OpenShift platform. Valid values are \\\\\"openshift\\\\\", \\\\\"crc (for CodeReady Containers)\\\\\".',\n\
       options: ['openshift', 'crc'],\n\
-      default: 'openshift'\n\
+      default: 'openshift',\n\
     }),"; # echo -e "$platformString"
 installerString="    installer: string({\n\
       char: 'a',\n\
@@ -131,7 +131,7 @@ clusterMonitoringString="    'cluster-monitoring': boolean({\n\
       default: false,\n\
       hidden: false,\n\
       description: \`Enable cluster monitoring to scrape CodeReady Workspaces metrics in Prometheus.\n\
-	                  This parameter is used only when the platform is 'openshift'.\`\n\
+	                  This parameter is used only when the platform is 'openshift'.\`,\n\
     }),"; # echo -e "$clusterMonitoringString"
 
 # set -x

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,12 +1,14 @@
-/*********************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
- *
+/**
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- **********************************************************************/
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 
 import { Command } from '@oclif/command'
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,0 @@
-{
-  "extends": "@oclif/tslint",
-  "rules": {
-    "object-curly-spacing": "always"
-  }
-}


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Upstream tslint was deprecated in favour of eslint: https://github.com/che-incubator/chectl/pull/1280
This PR add the correct config directory for eslint configurations
### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-1978