### PR TITLE
Adapt sync script to a new CRW operator repository

### DIFF
--- a/build/scripts/sync-chectl-to-crwctl.sh
+++ b/build/scripts/sync-chectl-to-crwctl.sh
@@ -116,7 +116,7 @@ pushd "${TARGETDIR}" >/dev/null
 	done <   <(find . -regextype posix-extended -iregex '.+/(helm|minishift|minishift-addon|minikube|microk8s|k8s|docker-desktop)(.test|).ts' -print0)
 popd >/dev/null
 
-# @since CRW-2150 - 2.11 sources have moved to https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
+# @since 2.11: CRW-2150 - sources have moved to https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
 # Update prepare-che-operator-templates.js
 pushd "${TARGETDIR}" >/dev/null
 	while IFS= read -r -d '' d; do
@@ -260,7 +260,7 @@ if [[ -f ${replaceFile} ]]; then
 		-e "s|codeready-operator|codeready-workspaces-operator|g"
 
 	echo "[INFO] Convert package.json (jq #1)"
-  # @since CRW-2150 - 2.11 sources have moved to https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
+  # @since 2.11: CRW-2150 - sources have moved to https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
 	declare -A package_replacements=(
 		["git://github.com/redhat-developer/codeready-workspaces-images#${MIDSTM_BRANCH}"]='.dependencies["codeready-workspaces-operator"]'
 		["crwctl"]='.name'

--- a/build/scripts/sync-chectl-to-crwctl.sh
+++ b/build/scripts/sync-chectl-to-crwctl.sh
@@ -117,10 +117,10 @@ pushd "${TARGETDIR}" >/dev/null
 popd >/dev/null
 
 # Update prepare-che-operator-templates.js
-# to copy resourcves from https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
+# to copy resources from https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
 pushd "${TARGETDIR}" >/dev/null
 	while IFS= read -r -d '' d; do
-		echo "[INFO] Convert ${d}"
+		echo "[INFO] Convert ${d} - use subfolder"
 		sed -r -e "s#'node_modules', 'codeready-workspaces-operator'#'node_modules', 'codeready-workspaces-operator', 'codeready-workspaces-operator'#" -i "${TARGETDIR}/${d}"
 	done <   <(find prepare-che-operator-templates.js -print0)
 popd >/dev/null

--- a/build/scripts/sync-chectl-to-crwctl.sh
+++ b/build/scripts/sync-chectl-to-crwctl.sh
@@ -116,8 +116,8 @@ pushd "${TARGETDIR}" >/dev/null
 	done <   <(find . -regextype posix-extended -iregex '.+/(helm|minishift|minishift-addon|minikube|microk8s|k8s|docker-desktop)(.test|).ts' -print0)
 popd >/dev/null
 
+# @since CRW-2150 - 2.11 sources have moved to https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
 # Update prepare-che-operator-templates.js
-# to copy resources from https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
 pushd "${TARGETDIR}" >/dev/null
 	while IFS= read -r -d '' d; do
 		echo "[INFO] Convert ${d} - use subfolder"
@@ -260,6 +260,7 @@ if [[ -f ${replaceFile} ]]; then
 		-e "s|codeready-operator|codeready-workspaces-operator|g"
 
 	echo "[INFO] Convert package.json (jq #1)"
+  # @since CRW-2150 - 2.11 sources have moved to https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
 	declare -A package_replacements=(
 		["git://github.com/redhat-developer/codeready-workspaces-images#${MIDSTM_BRANCH}"]='.dependencies["codeready-workspaces-operator"]'
 		["crwctl"]='.name'

--- a/build/scripts/sync-chectl-to-crwctl.sh
+++ b/build/scripts/sync-chectl-to-crwctl.sh
@@ -116,6 +116,15 @@ pushd "${TARGETDIR}" >/dev/null
 	done <   <(find . -regextype posix-extended -iregex '.+/(helm|minishift|minishift-addon|minikube|microk8s|k8s|docker-desktop)(.test|).ts' -print0)
 popd >/dev/null
 
+# Update prepare-che-operator-templates.js
+# to copy resourcves from https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-operator
+pushd "${TARGETDIR}" >/dev/null
+	while IFS= read -r -d '' d; do
+		echo "[INFO] Convert ${d}"
+		sed -r -e "s#'node_modules', 'codeready-workspaces-operator'#'node_modules', 'codeready-workspaces-operator', 'codeready-workspaces-operator'#" -i "${TARGETDIR}/${d}"
+	done <   <(find prepare-che-operator-templates.js -print0)
+popd >/dev/null
+
 # Rename files
 pushd "${TARGETDIR}" >/dev/null
 	while IFS= read -r -d '' d; do
@@ -252,7 +261,7 @@ if [[ -f ${replaceFile} ]]; then
 
 	echo "[INFO] Convert package.json (jq #1)"
 	declare -A package_replacements=(
-		["git://github.com/redhat-developer/codeready-workspaces-operator#${MIDSTM_BRANCH}"]='.dependencies["codeready-workspaces-operator"]'
+		["git://github.com/redhat-developer/codeready-workspaces-images#${MIDSTM_BRANCH}"]='.dependencies["codeready-workspaces-operator"]'
 		["crwctl"]='.name'
 		["CodeReady Workspaces CLI"]='.description'
 		["${DEFAULT_TAG}.0-CI-redhat"]='.version'


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
Adapt sync script to a new CRW operator repository

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20278
