### PR TITLE
CRW-2165 templates dir should be...

### DIFF
--- a/prepare-codeready-workspaces-operator-templates.js
+++ b/prepare-codeready-workspaces-operator-templates.js
@@ -14,7 +14,7 @@ const fs = require('fs-extra')
 const path = require('path')
 var deployFolder = path.join(__dirname, 'node_modules', 'codeready-workspaces-operator', 'codeready-workspaces-operator', 'deploy')
 var configFolder = path.join(__dirname, 'node_modules', 'codeready-workspaces-operator', 'codeready-workspaces-operator', 'config')
-var cheOperatorTemplates = path.join(__dirname, 'templates', 'codeready-operator')
+var cheOperatorTemplates = path.join(__dirname, 'templates', 'codeready-workspaces-operator')
 
 function prepareTemplates() {
     if (fs.existsSync(deployFolder)) {


### PR DESCRIPTION
### What does this PR do?

CRW-2165 templates dir should be templates/codeready-workspaces-operator, not templates/codeready-operator

Change-Id: I677a574cd640927ea030abf8592f210b5ca297de
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.