### PR TITLE
docs: removing `$ crwctl workspace:start --devfile` from `# Usage` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ running command...
 $ crwctl server:stop
 running command...
 
-$ crwctl workspace:start --devfile
-running command...
-
 $ crwctl --help [COMMAND]
 USAGE
   $ crwctl COMMAND


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
chectl's Contributing Guide: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md#push-changes-provide-pull-request
-->

### What does this PR do?
(I'm not sure if this PR is opened for the correct destination branch (or even repository): please check.)

Removing the orphaned `$ crwctl workspace:start --devfile` from the `# Usage` section of **README.md** because according to https://github.com/eclipse/che/issues/20671 `all workspace commands | broken | drop`.

The current state of [README.md](https://github.com/redhat-developer/codeready-workspaces-chectl#readme):
![image](https://user-images.githubusercontent.com/78564304/153465651-f2256e19-7edd-42a3-a2fd-9c1ace1feb32.png)

### What issues does this PR fix or reference?

